### PR TITLE
harden nginx: server_token off, and only enable ssl_protocols TLSv1.2…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The following environment variables will customize the runtime:
 | CERT_SIZE    | rsa:2048              | Size of the proxy certificate        |
 | CERT_SUBJECT | /CN=localhost         | CN for the certificate               |
 | BACKEND_URL  | http://127.0.0.1:8080 | Backend URL to proxy connections     |
-| LISTEN_PORT  | 8443                  | Proxy listen port                    |
+| LISTEN_PORT   | 8443                 | Proxy listen port                    |
+| SERVER_TOKENS | off                  | header server information            |
+| SSL_PROTOCOLS | TLSv1.2 TLSv1.3      | TLS protocols active                 |
 
 ## Author
 

--- a/config.sh
+++ b/config.sh
@@ -8,6 +8,8 @@ cert_size=${CERT_SIZE:-rsa:2048}
 cert_subject=${CERT_SUBJECT:-/CN=localhost}
 backend_url=${BACKEND_URL:-http://127.0.0.1:8080}
 listen_port=${LISTEN_PORT:-8443}
+server_tokens=${SERVER_TOKENS:-off}
+ssl_protocols=${SSL_PROTOCOLS:-"TLSv1.2 TLSv1.3"}
 
 echo "Generating SSL Certificate with expire: ${cert_expire}, size: ${cert_size}, subject: ${cert_subject}..."
 
@@ -18,11 +20,11 @@ echo "Configuring NGINX Proxy with listen port: ${listen_port}, backend url: ${b
 cat << EOF > /etc/nginx/sites-available/default
 server {
   listen ${listen_port};
-  server_tokens off;
+  server_tokens ${server_tokens};
   ssl on;
   ssl_certificate /etc/nginx/cert.crt;
   ssl_certificate_key /etc/nginx/cert.key;
-  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_protocols ${ssl_protocols};
   location / {
     proxy_ssl_session_reuse on;
 

--- a/config.sh
+++ b/config.sh
@@ -18,9 +18,11 @@ echo "Configuring NGINX Proxy with listen port: ${listen_port}, backend url: ${b
 cat << EOF > /etc/nginx/sites-available/default
 server {
   listen ${listen_port};
+  server_tokens off;
   ssl on;
   ssl_certificate /etc/nginx/cert.crt;
   ssl_certificate_key /etc/nginx/cert.key;
+  ssl_protocols TLSv1.2 TLSv1.3;
   location / {
     proxy_ssl_session_reuse on;
 


### PR DESCRIPTION
harden the nginxproxy sidecar configuration
- server_token off
- enable only ssl_protocols TLSv1.2 TLSv1.3